### PR TITLE
Fix color computation

### DIFF
--- a/RGB/RGBUIColor.swift
+++ b/RGB/RGBUIColor.swift
@@ -6,9 +6,9 @@ public func RGBUIColor(red red: Int, green: Int, blue: Int) -> UIColor {
 
 private func createColor(red: Int, green: Int, blue: Int) -> UIColor {
     return UIColor(
-        red: CGFloat(red/255),
-        green: CGFloat(green/255),
-        blue: CGFloat(blue/155),
+        red: CGFloat(red)/255,
+        green: CGFloat(green)/255,
+        blue: CGFloat(blue)/255,
         alpha: 1
     )
 }

--- a/RGBTests/RGBTests.swift
+++ b/RGBTests/RGBTests.swift
@@ -7,9 +7,9 @@ class RGBTests: QuickSpec {
         describe("RGBUIColor") {
             it("is a correct representation of the values") {
                 let thoughtbotRed = UIColor(
-                    red: CGFloat(195/255),
-                    green: CGFloat(47/255),
-                    blue: CGFloat(52/255),
+                    red: CGFloat(195.0/255.0),
+                    green: CGFloat(47.0/255.0),
+                    blue: CGFloat(52.0/255.0),
                     alpha: 1
                 )
                 let color = RGBUIColor(red: 195, green: 47, blue: 52)


### PR DESCRIPTION
The computation of the UIColor used integer division where it should
use floating-point division. This caused all RGB values < 255 to become
0.

In addition, there was a typo in the computation of the blue component.

The corresponding test did not catch these bugs because it essentially
contained the same code.
